### PR TITLE
adds MONGODB_URI as environment variable for MongoDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 #### 0.4.1 (Next)
 
 * [#28](https://github.com/slack-ruby/slack-ruby-bot-server/pull/28): Use slack-ruby-danger gem - [@dblock](https://github.com/dblock).
-* Your contribution here.
+* [#31](https://github.com/slack-ruby/slack-ruby-bot-server/pull/31): adds MONGODB_URI as environment variable for MongoDB - [@corprew](https://github.com/corprew).
+
 
 #### 0.4.0 (8/29/2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 #### 0.4.1 (Next)
 
 * [#28](https://github.com/slack-ruby/slack-ruby-bot-server/pull/28): Use slack-ruby-danger gem - [@dblock](https://github.com/dblock).
-* [#31](https://github.com/slack-ruby/slack-ruby-bot-server/pull/31): adds MONGODB_URI as environment variable for MongoDB - [@corprew](https://github.com/corprew).
-
+* [#31](https://github.com/slack-ruby/slack-ruby-bot-server/pull/31): Adds MONGODB_URI as environment variable for MongoDB - [@corprew](https://github.com/corprew).
+* Your contribution here.
 
 #### 0.4.0 (8/29/2016)
 

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :development, :test do
   gem 'database_cleaner'
   gem 'hyperclient'
   gem 'capybara'
-  gem 'selenium-webdriver'
+  gem 'selenium-webdriver', '~> 2.5'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
+  gem 'rack-server-pages', github: 'dblock/rack-server-pages', branch: 'next'
   gem 'bundler'
   gem 'rake'
   gem 'rspec'

--- a/lib/slack-ruby-bot-server/app.rb
+++ b/lib/slack-ruby-bot-server/app.rb
@@ -32,7 +32,9 @@ module SlackRubyBotServer
 
     def check_mongodb_provider!
       return unless ENV['RACK_ENV'] == 'production'
-      raise "Missing ENV['MONGO_URL'], ENV['MONGOHQ_URI'] or ENV['MONGOLAB_URI']." unless ENV['MONGO_URL'] || ENV['MONGOHQ_URI'] || ENV['MONGOLAB_URI']
+      unless ENV['MONGO_URL'] || ENV['MONGOHQ_URI'] || ENV['MONGODB_URI'] || ENV['MONGOLAB_URI']
+        raise "Missing ENV['MONGO_URL'], ENV['MONGOHQ_URI'], ENV['MONGODB_URI'], or ENV['MONGOLAB_URI']."
+      end
     end
 
     def check_database!

--- a/sample_app/config/mongoid.yml
+++ b/sample_app/config/mongoid.yml
@@ -21,7 +21,7 @@ test:
 production:
   clients:
     default:
-      uri: <%= ENV['MONGO_URL'] || ENV['MONGOHQ_URI'] || ENV['MONGOLAB_URI'] %>
+      uri: <%= ENV['MONGO_URL'] || ENV['MONGOHQ_URI'] || ENV['MONGOLAB_URI'] || ENV['MONGODB_URI'] %>
   options:
     raise_not_found_error: false
     use_utc: true


### PR DESCRIPTION
As described in #29, MongoLab rebranded itself as mLAB and now apparently sets MONGODB_URI as its environment variable for new addons.

Passes rubocop, but running specs reproducibly causes firefox to crash on my machine with or without this commit.

I left the old MONGOLAB_URI environment variable in order to not break existing installations using it.