### PR TITLE
Sample app: include broken dependencies, add instructions

### DIFF
--- a/sample_app/Gemfile
+++ b/sample_app/Gemfile
@@ -6,6 +6,7 @@ gem 'newrelic-slack-ruby-bot'
 group :test do
   gem 'rake'
   gem 'rspec'
+  gem 'rack-test'
   gem 'fabrication'
   gem 'faker'
   gem 'vcr'

--- a/sample_app/README.md
+++ b/sample_app/README.md
@@ -1,1 +1,13 @@
 This app is deployed from [github.com/slack-ruby/slack-ruby-bot-server-sample](https://github.com/slack-ruby/slack-ruby-bot-server-sample).
+
+[Register a new Slack app](https://api.slack.com/apps), configure a bot user, and OAuth redirect URL to http://localhost:9292 (for development). Configure your development environment by editing `.env` and setting the client ID and secret you were given during registration:
+
+    SLACK_CLIENT_ID=1111111111.2222222
+    SLACK_CLIENT_SECRET=abcdef012345679
+    PORT=9292
+
+Run tests with:
+
+    bundle exec rake
+
+

--- a/sample_app/spec/spec_helper.rb
+++ b/sample_app/spec/spec_helper.rb
@@ -3,6 +3,7 @@ $LOAD_PATH.unshift File.expand_path('..', __dir__)
 ENV['RACK_ENV'] = 'test'
 
 require 'slack-ruby-bot-server/rspec'
+require 'database_cleaner'
 
 Mongoid.load!(File.expand_path('../config/mongoid.yml', __dir__), ENV['RACK_ENV'])
 


### PR DESCRIPTION
On MRI 2.4, the specs inside the sample app were failing due to both `Rack::Test` and `DatabaseCleaner` being unavailable. This PR fixes those issues and includes some extra information in the README.