### PR TITLE
No need for otr-activerecord if using activerecord under Rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### 0.6.1 (Next)
 
 * Your contribution here.
+* [#53](https://github.com/slack-ruby/slack-ruby-bot-server/pull/53): No need for `otr-activerecord` if using activerecord under Rails - [@alexagranov](https://github.com/alexagranov).
 
 #### 0.6.0 (3/12/2017)
 

--- a/lib/slack-ruby-bot-server/api/middleware.rb
+++ b/lib/slack-ruby-bot-server/api/middleware.rb
@@ -1,7 +1,7 @@
 require 'rack/cors'
 require 'rack-rewrite'
 require 'rack-server-pages'
-require 'otr-activerecord' if SlackRubyBotServer::Config.activerecord?
+require 'otr-activerecord' if SlackRubyBotServer::Config.activerecord? && !defined?(::Rails)
 
 module SlackRubyBotServer
   module Api


### PR DESCRIPTION
So I'm actually using pieces of this nifty project under Rails via `rackup` and a custom server config.  

This allows me to leverage the same Rails stack (and Docker container) to run my customized subclass of `SlackRubyBotServer::Service`.

`otr-activerecord` is getting in the way and taking over some functionality, like logging levels.

Any suggestions on how to write a spec for this?  Not sure how I could pull in the rails gem...