### PR TITLE
Besides just exception message, log backtace as well.

### DIFF
--- a/lib/slack-ruby-bot-server/ext/activerecord/slack-ruby-bot/commands/base.rb
+++ b/lib/slack-ruby-bot-server/ext/activerecord/slack-ruby-bot/commands/base.rb
@@ -8,6 +8,7 @@ module SlackRubyBot
           _invoke client, data
         rescue StandardError => e
           logger.info "#{name.demodulize.upcase}: #{client.owner}, #{e.class}: #{e}"
+          logger.warn e.backtrace.join("\n")
           client.say(channel: data.channel, text: e.message, gif: 'error')
           true
         end

--- a/lib/slack-ruby-bot-server/ext/mongoid/slack-ruby-bot/commands/base.rb
+++ b/lib/slack-ruby-bot-server/ext/mongoid/slack-ruby-bot/commands/base.rb
@@ -12,6 +12,7 @@ module SlackRubyBot
           true
         rescue StandardError => e
           logger.info "#{name.demodulize.upcase}: #{client.owner}, #{e.class}: #{e}"
+          logger.warn e.backtrace.join("\n")
           client.say(channel: data.channel, text: e.message, gif: 'error')
           true
         end


### PR DESCRIPTION
Otherwise you'll have hard time debugging your bot command.

Before this update:

```
I, [2017-06-01T16:43:12.412298 #65958]  INFO -- : SUMMARYWEEK: name=private, domain=https://yosay.slack.com/services/B5LR26Q8P, id=T061XLE5B, NameError: undefined local variable or method `bin' for #<List:0x007ff9a3198710>
```

After this update:

```
I, [2017-06-01T16:51:48.876726 #67846]  INFO -- : SUMMARYWEEK: name=private, domain=https://yosay.slack.com/services/B5LR26Q8P, id=T061XLE5B, NameError: undefined local variable or method `bin' for #<List:0x007ff4db543d28>
I, [2017-06-01T16:51:48.876806 #67846]  INFO -- : /Users/nfedyashev/Projects/foo/models/list.rb:287:in `active_subscriptions_between'
	/Users/nfedyashev/Projects/foo/models/metrics_analyze.rb:14:in `active_percentage'
	/Users/nfedyashev/Projects/foo/commands/summary_week.rb:17:in `summary_week_content'
	/Users/nfedyashev/Projects/foo/commands/summary_week.rb:67:in `block in <class:SummaryWeek>'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/slack-ruby-bot-0.10.1/lib/slack-ruby-bot/commands/base.rb:71:in `call'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/slack-ruby-bot-0.10.1/lib/slack-ruby-bot/commands/base.rb:71:in `block in invoke'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/slack-ruby-bot-0.10.1/lib/slack-ruby-bot/commands/base.rb:56:in `each_pair'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/slack-ruby-bot-0.10.1/lib/slack-ruby-bot/commands/base.rb:56:in `invoke'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/slack-ruby-bot-server-0.6.1/lib/slack-ruby-bot-server/ext/activerecord/slack-ruby-bot/commands/base.rb:8:in `invoke'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/slack-ruby-bot-0.10.1/lib/slack-ruby-bot/hooks/message.rb:7:in `block in call'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/slack-ruby-bot-0.10.1/lib/slack-ruby-bot/hooks/message.rb:7:in `each'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/slack-ruby-bot-0.10.1/lib/slack-ruby-bot/hooks/message.rb:7:in `detect'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/slack-ruby-bot-0.10.1/lib/slack-ruby-bot/hooks/message.rb:7:in `call'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/slack-ruby-bot-0.10.1/lib/slack-ruby-bot/hooks/set.rb:35:in `block (2 levels) in register_callback'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/slack-ruby-bot-0.10.1/lib/slack-ruby-bot/hooks/set.rb:34:in `each'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/slack-ruby-bot-0.10.1/lib/slack-ruby-bot/hooks/set.rb:34:in `block in register_callback'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/slack-ruby-client-0.8.0/lib/slack/real_time/client.rb:188:in `call'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/slack-ruby-client-0.8.0/lib/slack/real_time/client.rb:188:in `block in run_callbacks'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/slack-ruby-client-0.8.0/lib/slack/real_time/client.rb:187:in `each'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/slack-ruby-client-0.8.0/lib/slack/real_time/client.rb:187:in `run_callbacks'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/slack-ruby-client-0.8.0/lib/slack/real_time/client.rb:168:in `dispatch'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/slack-ruby-client-0.8.0/lib/slack/real_time/client.rb:93:in `block (2 levels) in run_loop'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/websocket-driver-0.6.5/lib/websocket/driver/event_emitter.rb:39:in `call'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/websocket-driver-0.6.5/lib/websocket/driver/event_emitter.rb:39:in `block in emit'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/websocket-driver-0.6.5/lib/websocket/driver/event_emitter.rb:38:in `each'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/websocket-driver-0.6.5/lib/websocket/driver/event_emitter.rb:38:in `emit'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/websocket-driver-0.6.5/lib/websocket/driver/hybi.rb:396:in `emit_message'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/websocket-driver-0.6.5/lib/websocket/driver/hybi.rb:379:in `emit_frame'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/websocket-driver-0.6.5/lib/websocket/driver/hybi.rb:123:in `parse'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/websocket-driver-0.6.5/lib/websocket/driver/client.rb:63:in `parse'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/slack-ruby-client-0.8.0/lib/slack/real_time/concurrency/celluloid.rb:57:in `handle_read'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/celluloid-0.17.2/lib/celluloid/calls.rb:28:in `public_send'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/celluloid-0.17.2/lib/celluloid/calls.rb:28:in `dispatch'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/celluloid-0.17.2/lib/celluloid/call/async.rb:7:in `dispatch'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/celluloid-0.17.2/lib/celluloid/cell.rb:50:in `block in dispatch'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/celluloid-0.17.2/lib/celluloid/cell.rb:76:in `block in task'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/celluloid-0.17.2/lib/celluloid/actor.rb:339:in `block in task'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/celluloid-0.17.2/lib/celluloid/task.rb:44:in `block in initialize'
	/Users/nfedyashev/.rbenv/versions/2.2.6/lib/ruby/gems/2.2.0/gems/celluloid-0.17.2/lib/celluloid/task/fibered.rb:14:in `block in create'

```

HTH