### PR TITLE
Don't try to load OTR module is Rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [#60](https://github.com/slack-ruby/slack-ruby-bot-server/pull/60): Log caught Standard::Error backtrace at debug-level - [@alexagranov](https://github.com/alexagranov).
 * [#65](https://github.com/slack-ruby/slack-ruby-bot-server/pull/65): Updated Capybara and selenium-webdriver - [@dblock](https://github.com/dblock).
-* [#67](https://github.com/slack-ruby/slack-ruby-bot-server/pull/67): Only load the OTR::ActiveRecord::ConnectionManagement middleware when the OTR module is included. This module isn't needed when using Rails.
+* [#67](https://github.com/slack-ruby/slack-ruby-bot-server/pull/67): Only load the OTR::ActiveRecord::ConnectionManagement middleware when the OTR module is included. This module isn't needed when using Rails - [@darbyfrey](https://github.com/darbyfrey).
 * Your contribution here.
 
 #### 0.6.1 (3/29/2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#60](https://github.com/slack-ruby/slack-ruby-bot-server/pull/60): Log caught Standard::Error backtrace at debug-level - [@alexagranov](https://github.com/alexagranov).
 * [#65](https://github.com/slack-ruby/slack-ruby-bot-server/pull/65): Updated Capybara and selenium-webdriver - [@dblock](https://github.com/dblock).
+* [#67](https://github.com/slack-ruby/slack-ruby-bot-server/pull/67): Only load the OTR::ActiveRecord::ConnectionManagement middleware when the OTR module is included. This module isn't needed when using Rails.
 * Your contribution here.
 
 #### 0.6.1 (3/29/2017)

--- a/lib/slack-ruby-bot-server/api/middleware.rb
+++ b/lib/slack-ruby-bot-server/api/middleware.rb
@@ -15,7 +15,9 @@ module SlackRubyBotServer
 
       def self.instance
         @instance ||= Rack::Builder.new do
-          use OTR::ActiveRecord::ConnectionManagement if SlackRubyBotServer::Config.activerecord?
+          if SlackRubyBotServer::Config.activerecord? && defined?(::OTR)
+            use OTR::ActiveRecord::ConnectionManagement
+          end
 
           use Rack::Cors do
             allow do


### PR DESCRIPTION
`otr-activerecord` isn't loaded in Rails, so the middleware will fail with `uninitialized constant OTR`. This change will skip attempting to load `OTR::ActiveRecord::ConnectionManagement` if `OTR` is not defined (i.e. in Rails).