### PR TITLE
Documented obtaining access_token, closes #66. [ci skip]

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2016 Daniel Doubrovkine
+Copyright (c) 2015-2017 Daniel Doubrovkine & Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -166,13 +166,14 @@ You can see a sample implementation in [slack-sup#3a497b](https://github.com/dbl
 ### Examples Using Slack Ruby Bot Server
 
 * [slack-amber-alert](https://github.com/dblock/slack-amber-alert), free service at [missingkidsbot.org](https://www.missingkidsbot.org)
+* [slack-sup](https://github.com/dblock/slack-sup), free service at [sup.playplay.io](https://sup.playplay.io)
 * [slack-gamebot](https://github.com/dblock/slack-gamebot), free service at [www.playplay.io](https://www.playplay.io)
 * [slack-market](https://github.com/dblock/slack-market), free service at [market.playplay.io](https://market.playplay.io)
-* [slack-shallbot](https://github.com/slack-ruby/slack-shellbot), free service at [shell.playplay.io](https://shell.playplay.io)
+* [slack-shellbot](https://github.com/slack-ruby/slack-shellbot), free service at [shell.playplay.io](https://shell.playplay.io)
 * [slack-api-explorer](https://github.com/slack-ruby/slack-api-explorer), free service at [api-explorer.playplay.io](https://shell.playplay.io)
 
 ### Copyright & License
 
-Copyright [Daniel Doubrovkine](http://code.dblock.org), 2015-2016
+Copyright [Daniel Doubrovkine](http://code.dblock.org) and Contributors, 2015-2017
 
 [MIT License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -152,6 +152,17 @@ SlackRubyBotServer.configure do |config|
 end
 ```
 
+### Access Tokens
+
+By default the implementation of [Team](lib/slack-ruby-bot-server/models/team) stores a `bot_access_token` that grants a certain amount of privileges to the bot user as described in [Slack OAuth Docs](https://api.slack.com/docs/oauth). You may not want a bot user at all, or may require different auth scopes, such as `users.profile:read` to access user profile information via `Slack::Web::Client#users_profile_get`. To obtain the non-bot access token make the following changes.
+
+1) Configure your app to require additional scopes in Slack API under _OAuth_, _Permissions_
+2) Add `access_token` and, optionally, `scope` to your `Team` model
+3) Change the _Add to Slack_ buttons to require the additional scope, eg. `https://slack.com/oauth/authorize?scope=bot,users.profile:read&client_id=...`
+4) Store the access token returned from `Slack::Web::Client#oauth_access` and scope when creating a team in your `Teams` API endpoint.
+
+You can see a sample implementation in [slack-sup#3a497b](https://github.com/dblock/slack-sup/commit/3a497b436d25d3a7738562655cda64b180ae0096).
+
 ### Examples Using Slack Ruby Bot Server
 
 * [slack-amber-alert](https://github.com/dblock/slack-amber-alert), free service at [missingkidsbot.org](https://www.missingkidsbot.org)


### PR DESCRIPTION
The implementation has proven to be annoying enough that people can roll their own.