### PR TITLE
Fix: compatibility with Grape 1.2.x.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 0.8.3 (Next)
 
+* [#88](https://github.com/slack-ruby/slack-ruby-bot-server/issues/88): Fix: compatibility with Grape 1.2.x - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 #### 0.8.2 (2018/10/11)

--- a/lib/slack-ruby-bot-server/ext/grape/sort_extension.rb
+++ b/lib/slack-ruby-bot-server/ext/grape/sort_extension.rb
@@ -1,8 +1,18 @@
 module Grape
   class API
-    def self.sort(value)
-      route_setting :sort, sort: value
-      value
+    module Extensions
+      module SortExtension
+        def sort(value)
+          route_setting :sort, sort: value
+          value
+        end
+      end
     end
   end
+end
+
+if defined? Grape::API::Instance
+  Grape::API::Instance.extend Grape::API::Extensions::SortExtension
+else
+  Grape::API.extend Grape::API::Extensions::SortExtension
 end


### PR DESCRIPTION
Fixes https://github.com/slack-ruby/slack-ruby-bot-server/issues/88.

Grape API objects are now `Grape::API::Instance`, so monkey patching needs to happen on the right class.