### PR TITLE
Add example for reading env variables in yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### 0.8.4 (Next)
 
 * Your contribution here.
+* [#90](https://github.com/slack-ruby/slack-ruby-bot-server/pull/90): Update ActiveRecord sample app to support ENV variables in `postgresql.yml` - [@ashkan18](https://github.com/ashkan18).
 
 #### 0.8.3 (2019/01/17)
 

--- a/sample_apps/sample_app_activerecord/config.ru
+++ b/sample_apps/sample_app_activerecord/config.ru
@@ -4,8 +4,15 @@ Bundler.require :default
 
 require_relative 'commands'
 require 'yaml'
+require 'erb'
 
-ActiveRecord::Base.establish_connection(YAML.load_file('config/postgresql.yml')[ENV['RACK_ENV']])
+ActiveRecord::Base.establish_connection(
+  YAML.safe_load(
+    ERB.new(
+      File.read('config/postgresql.yml')
+    ).result
+  )[ENV['RACK_ENV']]
+)
 
 NewRelic::Agent.manual_start
 

--- a/sample_apps/sample_app_activerecord/config/postgresql.yml
+++ b/sample_apps/sample_app_activerecord/config/postgresql.yml
@@ -14,4 +14,4 @@ test:
 
 production:
   <<: *default
-  database: slack_ruby_bot_server_production
+  url: <%= ENV["DATABASE_URL"] %>


### PR DESCRIPTION
# Improvement
When following `ActiveRecord` example and trying to deploy to Heroku, had to update `postgresql.yml` to support ENV variables. Updated example to include how to do that.