### PR TITLE
Added Config#service_class to override the SlackRubyBotServer::Service.instance singleton.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 0.10.0 (Next)
 
+* [#97](https://github.com/slack-ruby/slack-ruby-bot-server/pull/97): Added `Config#service_class` to override the `SlackRubyBotServer::Service.instance` singleton - [@dblock](https://github.com/dblock).
 * [#96](https://github.com/slack-ruby/slack-ruby-bot-server/pull/96): Added `Team#bot_user_id`, `activated_user_id` and `activated_user_access_token` - [@dblock](https://github.com/dblock).
 * Your contribution here.
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ instance.on :creating do |team, error, options|
 end
 ```
 
-
 #### Server Class
 
 You can override the server class to handle additional events, and configure the service to use it.
@@ -166,6 +165,25 @@ end
 SlackRubyBotServer.configure do |config|
   config.server_class = MyServer
 end
+```
+
+#### Service Class
+
+You can override the service class to handle additional methods.
+
+```ruby
+class MyService < SlackRubyBotServer::Service
+  def url
+    'https://www.example.com'
+  end
+end
+
+SlackRubyBotServer.configure do |config|
+  config.service_class = MyService
+end
+
+SlackRubyBotServer::Service.instance # MyService
+SlackRubyBotServer::Service.instance.url # https://www.example.com
 ```
 
 ### Access Tokens

--- a/lib/slack-ruby-bot-server.rb
+++ b/lib/slack-ruby-bot-server.rb
@@ -2,6 +2,7 @@ require 'async/websocket'
 
 require 'grape-swagger'
 require 'slack-ruby-bot'
+require 'slack-ruby-bot-server/service'
 require 'slack-ruby-bot-server/server'
 require 'slack-ruby-bot-server/config'
 
@@ -13,4 +14,3 @@ require "slack-ruby-bot-server/config/database_adapters/#{SlackRubyBotServer::Co
 
 require 'slack-ruby-bot-server/api'
 require 'slack-ruby-bot-server/app'
-require 'slack-ruby-bot-server/service'

--- a/lib/slack-ruby-bot-server/config.rb
+++ b/lib/slack-ruby-bot-server/config.rb
@@ -3,10 +3,12 @@ module SlackRubyBotServer
     extend self
 
     attr_accessor :server_class
+    attr_accessor :service_class
     attr_accessor :database_adapter
 
     def reset!
       self.server_class = SlackRubyBotServer::Server
+      self.service_class = SlackRubyBotServer::Service
       self.database_adapter = if defined?(::Mongoid)
                                 :mongoid
                               elsif defined?(::ActiveRecord)

--- a/lib/slack-ruby-bot-server/service.rb
+++ b/lib/slack-ruby-bot-server/service.rb
@@ -10,7 +10,7 @@ module SlackRubyBotServer
     end
 
     def self.instance
-      @instance ||= new
+      @instance ||= SlackRubyBotServer::Config.service_class.new
     end
 
     def initialize

--- a/spec/slack-ruby-bot-server/service_spec.rb
+++ b/spec/slack-ruby-bot-server/service_spec.rb
@@ -87,4 +87,23 @@ describe SlackRubyBotServer::Service do
       expect(@events).to eq %w[starting started stopping stopped]
     end
   end
+  context 'overriding service_class' do
+    let(:service_class) do
+      Class.new(SlackRubyBotServer::Service) do
+        def url
+          'https://www.example.com'
+        end
+      end
+    end
+    after do
+      SlackRubyBotServer.config.reset!
+    end
+    it 'creates an instance of service class' do
+      SlackRubyBotServer.configure do |config|
+        config.service_class = service_class
+      end
+      expect(SlackRubyBotServer::Service.instance).to be_a service_class
+      expect(SlackRubyBotServer::Service.instance.url).to eq 'https://www.example.com'
+    end
+  end
 end


### PR DESCRIPTION
There's probable a better way to do this.

I had to get rid of the custom one in https://github.com/dblock/slack-moji/commit/810d5a27480f0aa19ffcd1b1414a37a3335a8ad8 to get the mailchimp plugin callbacks. This helps with that.