### PR TITLE
Removed migration code from legacy SLACK_API_TOKEN.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 0.10.1 (Next)
 
+* [#101](https://github.com/slack-ruby/slack-ruby-bot-server/pull/101): Removed support for migrating from a legacy `SLACK_API_TOKEN` - [@dblock](https://github.com/dblock).
 * [#98](https://github.com/slack-ruby/slack-ruby-bot-server/pull/98): Removed `unicorn` from gem dependencies - [@dblock](https://github.com/dblock).
 * [#90](https://github.com/slack-ruby/slack-ruby-bot-server/pull/90): Update ActiveRecord sample app to support ENV variables in `postgresql.yml` - [@ashkan18](https://github.com/ashkan18).
 * Your contribution here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### 0.10.1 (Next)
 
-* [#101](https://github.com/slack-ruby/slack-ruby-bot-server/pull/101): Removed support for migrating from a legacy `SLACK_API_TOKEN` - [@dblock](https://github.com/dblock).
+* [#101](https://github.com/slack-ruby/slack-ruby-bot-server/pull/101): Removed legacy migrations, including `SLACK_API_TOKEN`, team `name`, `team_id` and `active` - [@dblock](https://github.com/dblock).
 * [#98](https://github.com/slack-ruby/slack-ruby-bot-server/pull/98): Removed `unicorn` from gem dependencies - [@dblock](https://github.com/dblock).
 * [#90](https://github.com/slack-ruby/slack-ruby-bot-server/pull/90): Update ActiveRecord sample app to support ENV variables in `postgresql.yml` - [@ashkan18](https://github.com/ashkan18).
 * Your contribution here.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,9 +3,9 @@ Upgrading Slack-Ruby-Bot-Server
 
 ### Upgrading to >= 0.10.1
 
-#### Migration from SLACK_API_TOKEN
+#### Removed Legacy Migrations
 
-The code to automatically migrate from a legacy SLACK_API_TOKEN has been removed.
+Several legacy migrations have been removed, including the code to automatically create a team from a legacy `SLACK_API_TOKEN`, setting `Team#active`, `name` and `team_id`.
 
 See [#101](https://github.com/slack-ruby/slack-ruby-bot-server/pull/101) for more information.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,12 @@ Upgrading Slack-Ruby-Bot-Server
 
 ### Upgrading to >= 0.10.1
 
+#### Migration from SLACK_API_TOKEN
+
+The code to automatically migrate from a legacy SLACK_API_TOKEN has been removed.
+
+See [#101](https://github.com/slack-ruby/slack-ruby-bot-server/pull/101) for more information.
+
 #### Unicorn Dependency
 
 The dependency on `unicorn` has been removed from gemspec. Use `unicorn` or `puma` or another application server as you see fit by explicitly adding a dependency in your Gemfile.

--- a/lib/slack-ruby-bot-server/app.rb
+++ b/lib/slack-ruby-bot-server/app.rb
@@ -4,7 +4,6 @@ module SlackRubyBotServer
       check_database!
       init_database!
       mark_teams_active!
-      migrate_from_single_team!
       update_team_name_and_id!
       purge_inactive_teams!
       configure_global_aliases!
@@ -45,14 +44,6 @@ module SlackRubyBotServer
           team.set(active: false)
         end
       end
-    end
-
-    def migrate_from_single_team!
-      return unless ENV.key?('SLACK_API_TOKEN')
-      logger.info 'Migrating from env SLACK_API_TOKEN ...'
-      team = Team.find_or_create_from_env!
-      logger.info "Automatically migrated team: #{team}."
-      logger.warn "You should unset ENV['SLACK_API_TOKEN']."
     end
 
     def purge_inactive_teams!

--- a/lib/slack-ruby-bot-server/app.rb
+++ b/lib/slack-ruby-bot-server/app.rb
@@ -3,7 +3,6 @@ module SlackRubyBotServer
     def prepare!
       check_database!
       init_database!
-      mark_teams_active!
       purge_inactive_teams!
       configure_global_aliases!
     end
@@ -27,10 +26,6 @@ module SlackRubyBotServer
 
     def init_database!
       SlackRubyBotServer::DatabaseAdapter.init!
-    end
-
-    def mark_teams_active!
-      Team.where(active: nil).update_all(active: true)
     end
 
     def purge_inactive_teams!

--- a/lib/slack-ruby-bot-server/app.rb
+++ b/lib/slack-ruby-bot-server/app.rb
@@ -4,7 +4,6 @@ module SlackRubyBotServer
       check_database!
       init_database!
       mark_teams_active!
-      update_team_name_and_id!
       purge_inactive_teams!
       configure_global_aliases!
     end
@@ -32,18 +31,6 @@ module SlackRubyBotServer
 
     def mark_teams_active!
       Team.where(active: nil).update_all(active: true)
-    end
-
-    def update_team_name_and_id!
-      Team.active.where(team_id: nil).each do |team|
-        begin
-          auth = team.ping![:auth]
-          team.update_attributes!(team_id: auth['team_id'], name: auth['team'])
-        rescue StandardError => e
-          logger.warn "Error pinging team #{team.id}: #{e.message}."
-          team.set(active: false)
-        end
-      end
     end
 
     def purge_inactive_teams!

--- a/lib/slack-ruby-bot-server/models/team/methods.rb
+++ b/lib/slack-ruby-bot-server/models/team/methods.rb
@@ -38,18 +38,5 @@ module Methods
         presence: client.users_getPresence(user: auth['user_id'])
       }
     end
-
-    def self.find_or_create_from_env!
-      token = ENV['SLACK_API_TOKEN']
-      return unless token
-      team = Team.where(token: token).first
-      team ||= Team.new(token: token)
-      info = Slack::Web::Client.new(token: token).team_info
-      team.team_id = info['team']['id']
-      team.name = info['team']['name']
-      team.domain = info['team']['domain']
-      team.save!
-      team
-    end
   end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -1,24 +1,6 @@
 require 'spec_helper'
 
 describe Team do
-  context '#find_or_create_from_env!' do
-    before do
-      ENV['SLACK_API_TOKEN'] = 'token'
-    end
-    context 'team', vcr: { cassette_name: 'team_info' } do
-      it 'creates a team' do
-        expect { Team.find_or_create_from_env! }.to change(Team, :count).by(1)
-        team = Team.first
-        expect(team.team_id).to eq 'T04KB5WQH'
-        expect(team.name).to eq 'dblock'
-        expect(team.domain).to eq 'dblockdotorg'
-        expect(team.token).to eq 'token'
-      end
-    end
-    after do
-      ENV.delete 'SLACK_API_TOKEN'
-    end
-  end
   context '#purge!' do
     let!(:active_team) { Fabricate(:team) }
     let!(:inactive_team) { Fabricate(:team, active: false) }


### PR DESCRIPTION
Closes #37.