### PR TITLE
Lock async-websocket at a compatible version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 0.11.1 (Next)
 
+* [#104](https://github.com/slack-ruby/slack-ruby-bot-server/pull/104): Lock async-websocket at a compatible 0.8.0 version - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 #### 0.11.0 (2019/4/12)

--- a/slack-ruby-bot-server.gemspec
+++ b/slack-ruby-bot-server.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'async-websocket'
+  spec.add_dependency 'async-websocket', '~> 0.8.0'
   spec.add_dependency 'foreman'
   spec.add_dependency 'grape'
   spec.add_dependency 'grape-roar', '>= 0.4.0'


### PR DESCRIPTION
Via https://github.com/slack-ruby/slack-ruby-client/pull/268