### PR TITLE
update README to use oauth V2 for Slack Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Changelog
 
+#### 0.12.3 (Next)
+
+* Your contribution here.
+
 #### 0.12.3 (2020/8/17)
 
 * [#125](https://github.com/slack-ruby/slack-ruby-bot-server/pull/125): Update readme to use oauth v2 for slack button - [@amclelland](https://github.com/amclelland).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ### Changelog
 
-#### 0.12.3 (Next)
+#### 0.12.3 (2020/8/17)
 
-* Your contribution here.
+* [#125](https://github.com/slack-ruby/slack-ruby-bot-server/pull/125): Update readme to use oauth v2 for slack button - [@amclelland](https://github.com/amclelland).
 
 #### 0.12.2 (2020/7/26)
 

--- a/README.md
+++ b/README.md
@@ -112,14 +112,14 @@ Once clicked, the user is taken through the authorization process at Slack's sit
 client = Slack::Web::Client.new
 
 # Request a token using the temporary code
-rc = client.oauth_access(
+rc = client.oauth_v2_access(
   client_id: ENV['SLACK_CLIENT_ID'],
   client_secret: ENV['SLACK_CLIENT_SECRET'],
   code: params[:code]
 )
 
 # Pluck the token from the response
-token = rc['bot']['bot_access_token']
+token = rc[:access_token]
 ```
 
 The token is stored in persistent storage and used each time a Slack client is instantiated for the specific team.


### PR DESCRIPTION
this is related to https://github.com/slack-ruby/slack-ruby-bot-server/issues/108

New flow for using the Slack button here using the v2 oauth.