### PR TITLE
Fix missing Boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### 1.2.1 (Next)
 
 * [#137](https://github.com/slack-ruby/slack-ruby-bot-server/pull/137): Fix missing Boolean definition - [@icco](https://github.com/icco).
+* Your contribution here.
 
 #### 1.2.0 (2020/11/27)
 

--- a/lib/slack-ruby-bot-server/api/endpoints/teams_endpoint.rb
+++ b/lib/slack-ruby-bot-server/api/endpoints/teams_endpoint.rb
@@ -19,7 +19,7 @@ module SlackRubyBotServer
 
           desc 'Get all the teams.'
           params do
-            optional :active, type: Boolean, desc: 'Return active teams only.'
+            optional :active, type: Grape::API::Boolean, desc: 'Return active teams only.'
             use :pagination
           end
           sort Team::SORT_ORDERS

--- a/lib/slack-ruby-bot-server/api/presenters/team_presenter.rb
+++ b/lib/slack-ruby-bot-server/api/presenters/team_presenter.rb
@@ -10,7 +10,7 @@ module SlackRubyBotServer
         property :team_id, type: String, desc: 'Slack team ID.'
         property :name, type: String, desc: 'Team name.'
         property :domain, type: String, desc: 'Team domain.'
-        property :active, type: Boolean, desc: 'Team is active.'
+        property :active, type: Grape::API::Boolean, desc: 'Team is active.'
         property :created_at, type: DateTime, desc: 'Date/time when the team was created.'
         property :updated_at, type: DateTime, desc: 'Date/time when the team was accepted, declined or canceled.'
 

--- a/lib/slack-ruby-bot-server/config/database_adapters/mongoid.rb
+++ b/lib/slack-ruby-bot-server/config/database_adapters/mongoid.rb
@@ -24,3 +24,5 @@ module SlackRubyBotServer
     end
   end
 end
+
+::Boolean = Grape::API::Boolean

--- a/lib/slack-ruby-bot-server/config/database_adapters/mongoid.rb
+++ b/lib/slack-ruby-bot-server/config/database_adapters/mongoid.rb
@@ -24,5 +24,3 @@ module SlackRubyBotServer
     end
   end
 end
-
-::Boolean = Grape::API::Boolean


### PR DESCRIPTION
Fixes error when using Mongoid:  <module:TeamPresenter>: uninitialized constant SlackRubyBotServer::Api::Presenters::TeamPresenter::Boolean (NameError).

I saw this just by running https://github.com/slack-ruby/slack-ruby-bot-server-events-app-mentions-sample, which uses mongoid. Patched locally and worked. Line copied from activerecord code: https://github.com/slack-ruby/slack-ruby-bot-server/blob/99e91edbc3092dc9f9665fb8c9be3eebff3252f1/lib/slack-ruby-bot-server/config/database_adapters/activerecord.rb#L33