### PR TITLE
chore(test): enable mongoid use db config from ENV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#145](https://github.com/slack-ruby/slack-ruby-bot-server/pull/145): Added support for Ruby 3.1 - [@dblock](https://github.com/dblock).
 * [#146](https://github.com/slack-ruby/slack-ruby-bot-server/pull/146): Added support for MongoDB 5.0 - [@dblock](https://github.com/dblock).
 * [#147](https://github.com/slack-ruby/slack-ruby-bot-server/pull/147): Added support for PostgreSQL 14 - [@dblock](https://github.com/dblock).
+* [#155](https://github.com/slack-ruby/slack-ruby-bot-server/pull/155): Enable mongoid to get connection URI from ENV for test - [@crazyoptimist](https://github.com/crazyoptimist)
 * Your contribution here.
 
 #### 1.2.1 (2022/03/06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * [#145](https://github.com/slack-ruby/slack-ruby-bot-server/pull/145): Added support for Ruby 3.1 - [@dblock](https://github.com/dblock).
 * [#146](https://github.com/slack-ruby/slack-ruby-bot-server/pull/146): Added support for MongoDB 5.0 - [@dblock](https://github.com/dblock).
 * [#147](https://github.com/slack-ruby/slack-ruby-bot-server/pull/147): Added support for PostgreSQL 14 - [@dblock](https://github.com/dblock).
-* [#155](https://github.com/slack-ruby/slack-ruby-bot-server/pull/155): Enable mongoid to get connection URI from ENV for test - [@crazyoptimist](https://github.com/crazyoptimist)
+* [#155](https://github.com/slack-ruby/slack-ruby-bot-server/pull/155): Enable mongoid to get connection URI from ENV for test - [@crazyoptimist](https://github.com/crazyoptimist).
 * Your contribution here.
 
 #### 1.2.1 (2022/03/06)

--- a/spec/database_adapters/mongoid/config/mongoid.yml
+++ b/spec/database_adapters/mongoid/config/mongoid.yml
@@ -11,9 +11,7 @@ development:
 test:
   clients:
     default:
-      database: bot-server_test
-      hosts:
-        - 127.0.0.1:27017
+      uri: <%= ENV["DATABASE_URL"] || 'mongodb://localhost' %>
   options:
     raise_not_found_error: false
     use_utc: true


### PR DESCRIPTION
## Description
Not everyone use no-auth mongodb in the dev environment. For my case as an example, I have a mongodb container running on my local machine which is auth configured. So we need to be able to use mongo connection URI from ENV. It's already configured like that in `slack-ruby-bot-server-events`.
Remote URIs won't work in the test environment because `database_cleaner` prevents it, but auth should still be allowed.