### PR TITLE
doc: add test env setup guide for linux users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#146](https://github.com/slack-ruby/slack-ruby-bot-server/pull/146): Added support for MongoDB 5.0 - [@dblock](https://github.com/dblock).
 * [#147](https://github.com/slack-ruby/slack-ruby-bot-server/pull/147): Added support for PostgreSQL 14 - [@dblock](https://github.com/dblock).
 * [#155](https://github.com/slack-ruby/slack-ruby-bot-server/pull/155): Enable mongoid to get connection URI from ENV for test - [@crazyoptimist](https://github.com/crazyoptimist).
+* [#157](https://github.com/slack-ruby/slack-ruby-bot-server/pull/157): Added test env setup guide for linux users - [@crazyoptimist](https://github.com/crazyoptimist).
 * Your contribution here.
 
 #### 1.2.1 (2022/03/06)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,13 @@ bundle install
 bundle exec rake
 ```
 
+If you are a linux user, you will need to install [geckodriver](https://github.com/mozilla/geckodriver/releases), [firefox](https://download-installer.cdn.mozilla.net/pub/firefox/releases/), and `Xvfb`.  
+And, to get a display for the headless browser, run `Xvfb` manually. You can see more explanations [here](http://elementalselenium.com/tips/38-headless).
+
+```
+xvfb-run --auto-servernum bundle exec rake
+```
+
 ## Write Tests
 
 Try to write a test that reproduces the problem you're trying to fix or describes a feature that you want to build.


### PR DESCRIPTION
Want to add an explicit test env setup guideline for contributors that use linux.