### PR TITLE
Replace cursor_pagination with pagy_cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#147](https://github.com/slack-ruby/slack-ruby-bot-server/pull/147): Added support for PostgreSQL 14 - [@dblock](https://github.com/dblock).
 * [#155](https://github.com/slack-ruby/slack-ruby-bot-server/pull/155): Enable mongoid to get connection URI from ENV for test - [@crazyoptimist](https://github.com/crazyoptimist).
 * [#157](https://github.com/slack-ruby/slack-ruby-bot-server/pull/157): Added test env setup guide for linux users - [@crazyoptimist](https://github.com/crazyoptimist).
+* [#158](https://github.com/slack-ruby/slack-ruby-bot-server/pull/158): Replace `cursor_pagination` with `pagy_cursor` - [@crazyoptimist](https://github.com/crazyoptimist).
 * Your contribution here.
 
 #### 1.2.1 (2022/03/06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### Changelog
 
-#### 1.2.2 (Next)
+#### 2.0.0 (Next)
 
 * [#145](https://github.com/slack-ruby/slack-ruby-bot-server/pull/145): Added support for Ruby 3.1 - [@dblock](https://github.com/dblock).
 * [#146](https://github.com/slack-ruby/slack-ruby-bot-server/pull/146): Added support for MongoDB 5.0 - [@dblock](https://github.com/dblock).

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ when 'mongoid' then
 when 'activerecord' then
   gem 'activerecord', '~> 6.0.0'
   gem 'otr-activerecord'
-  gem 'cursor_pagination', github: 'dblock/cursor_pagination', branch: 'misc' # rubocop:disable Bundler/OrderedGems
+  gem 'pagy_cursor'
   gem 'pg'
 when nil
   warn "Missing ENV['DATABASE_ADAPTER']."

--- a/README.md
+++ b/README.md
@@ -65,14 +65,14 @@ gem 'slack-ruby-bot-server'
 
 #### ActiveRecord
 
-Use ActiveRecord with, for example, PostgreSQL via [pg](https://github.com/ged/ruby-pg). Add the `activerecord`, `pg`, `otr-activerecord` and `cursor_pagination` gems to your Gemfile.
+Use ActiveRecord with, for example, PostgreSQL via [pg](https://github.com/ged/ruby-pg). Add the `activerecord`, `pg`, `otr-activerecord` and `pagy_cursor` gems to your Gemfile.
 
 ```
 gem 'pg'
 gem 'activerecord', require: 'active_record'
 gem 'slack-ruby-bot-server'
 gem 'otr-activerecord'
-gem 'cursor_pagination'
+gem 'pagy_cursor'
 ```
 
 Configure the database connection in `config/postgresql.yml`. 

--- a/lib/slack-ruby-bot-server.rb
+++ b/lib/slack-ruby-bot-server.rb
@@ -2,6 +2,8 @@ require 'async'
 
 require 'slack-ruby-client'
 require 'grape-swagger'
+require 'pagy'
+require 'pagy_cursor/pagy/extras/cursor'
 
 require_relative 'slack-ruby-bot-server/loggable'
 require_relative 'slack-ruby-bot-server/service'

--- a/lib/slack-ruby-bot-server/api/helpers/cursor_helpers.rb
+++ b/lib/slack-ruby-bot-server/api/helpers/cursor_helpers.rb
@@ -37,7 +37,7 @@ module SlackRubyBotServer
             cursor_direction = :after
             sort_order(options).each do |order|
               sort_options[order[:column]] = { reverse: true } if order[:direction] == :desc
-              cursor_direction = :before if order[:column] == coll.primary_key and order[:direction] == :desc
+              cursor_direction = :before if order[:column] == coll.primary_key && order[:direction] == :desc
             end
             cursor_vars = { items: size }
             cursor_vars[cursor_direction] = params[:cursor].to_i if params.key?(:cursor)

--- a/lib/slack-ruby-bot-server/api/helpers/cursor_helpers.rb
+++ b/lib/slack-ruby-bot-server/api/helpers/cursor_helpers.rb
@@ -3,6 +3,7 @@ module SlackRubyBotServer
     module Helpers
       module CursorHelpers
         extend ActiveSupport::Concern
+        include Pagy::Cursor::Backend
 
         # apply cursor-based pagination to a collection
         # returns a hash:
@@ -30,15 +31,10 @@ module SlackRubyBotServer
 
             results = { results: [], next: nil }
             size = (params[:size] || 10).to_i
-            results[:total_count] = coll.count(:all) if params[:total_count]
-            coll = coll.offset(params[:offset].to_i) if params.key?(:offset)
-            sort_options = {}
-            sort_order(options).each do |order|
-              sort_options[order[:column]] = { reverse: true } if order[:direction] == :desc
-            end
-            coll = coll.cursor(params[:cursor], columns: sort_options).per(size)
+            pagy_cursor, coll = pagy_cursor(coll, items: size)
+
+            puts pagy_cursor.inspect
             results[:results] = coll.to_a
-            results[:next] = coll.next_cursor.to_s unless coll.last_page?
             results
           end
         end

--- a/lib/slack-ruby-bot-server/config/pagy.rb
+++ b/lib/slack-ruby-bot-server/config/pagy.rb
@@ -1,0 +1,246 @@
+# frozen_string_literal: true
+
+# Pagy initializer file (6.0.0)
+# Customize only what you really need and notice that the core Pagy works also without any of the following lines.
+# Should you just cherry pick part of this file, please maintain the require-order of the extras
+
+
+# Pagy DEFAULT Variables
+# See https://ddnexus.github.io/pagy/docs/api/pagy#variables
+# All the Pagy::DEFAULT are set for all the Pagy instances but can be overridden per instance by just passing them to
+# Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
+
+
+# Instance variables
+# See https://ddnexus.github.io/pagy/docs/api/pagy#instance-variables
+# Pagy::DEFAULT[:page]   = 1                                  # default
+# Pagy::DEFAULT[:items]  = 20                                 # default
+# Pagy::DEFAULT[:outset] = 0                                  # default
+
+
+# Other Variables
+# See https://ddnexus.github.io/pagy/docs/api/pagy#other-variables
+# Pagy::DEFAULT[:size]       = [1,4,4,1]                       # default
+# Pagy::DEFAULT[:page_param] = :page                           # default
+# The :params can be also set as a lambda e.g ->(params){ params.exclude('useless').merge!('custom' => 'useful') }
+# Pagy::DEFAULT[:params]     = {}                              # default
+# Pagy::DEFAULT[:fragment]   = '#fragment'                     # example
+# Pagy::DEFAULT[:link_extra] = 'data-remote="true"'            # example
+# Pagy::DEFAULT[:i18n_key]   = 'pagy.item_name'                # default
+# Pagy::DEFAULT[:cycle]      = true                            # example
+# Pagy::DEFAULT[:request_path] = "/foo"                        # example
+
+
+# Extras
+# See https://ddnexus.github.io/pagy/docs/extras
+
+
+# Backend Extras
+
+# Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
+# See https://ddnexus.github.io/pagy/docs/extras/array
+# require 'pagy/extras/array'
+
+# Calendar extra: Add pagination filtering by calendar time unit (year, quarter, month, week, day)
+# See https://ddnexus.github.io/pagy/docs/extras/calendar
+# require 'pagy/extras/calendar'
+# Default for each unit
+# Pagy::Calendar::Year::DEFAULT[:order]     = :asc        # Time direction of pagination
+# Pagy::Calendar::Year::DEFAULT[:format]    = '%Y'        # strftime format
+#
+# Pagy::Calendar::Quarter::DEFAULT[:order]  = :asc        # Time direction of pagination
+# Pagy::Calendar::Quarter::DEFAULT[:format] = '%Y-Q%q'    # strftime format
+#
+# Pagy::Calendar::Month::DEFAULT[:order]    = :asc        # Time direction of pagination
+# Pagy::Calendar::Month::DEFAULT[:format]   = '%Y-%m'     # strftime format
+#
+# Pagy::Calendar::Week::DEFAULT[:order]     = :asc        # Time direction of pagination
+# Pagy::Calendar::Week::DEFAULT[:format]    = '%Y-%W'     # strftime format
+#
+# Pagy::Calendar::Day::DEFAULT[:order]      = :asc        # Time direction of pagination
+# Pagy::Calendar::Day::DEFAULT[:format]     = '%Y-%m-%d'  # strftime format
+#
+# Uncomment the following lines, if you need calendar localization without using the I18n extra
+# module LocalizePagyCalendar
+#   def localize(time, opts)
+#     ::I18n.l(time, **opts)
+#   end
+# end
+# Pagy::Calendar.prepend LocalizePagyCalendar
+
+# Countless extra: Paginate without any count, saving one query per rendering
+# See https://ddnexus.github.io/pagy/docs/extras/countless
+# require 'pagy/extras/countless'
+# Pagy::DEFAULT[:countless_minimal] = false   # default (eager loading)
+
+# Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
+# See https://ddnexus.github.io/pagy/docs/extras/elasticsearch_rails
+# Default :pagy_search method: change only if you use also
+# the searchkick or meilisearch extra that defines the same
+# Pagy::DEFAULT[:elasticsearch_rails_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:elasticsearch_rails_search] = :search
+# require 'pagy/extras/elasticsearch_rails'
+
+# Headers extra: http response headers (and other helpers) useful for API pagination
+# See http://ddnexus.github.io/pagy/extras/headers
+# require 'pagy/extras/headers'
+# Pagy::DEFAULT[:headers] = { page: 'Current-Page',
+#                            items: 'Page-Items',
+#                            count: 'Total-Count',
+#                            pages: 'Total-Pages' }     # default
+
+# Meilisearch extra: Paginate `Meilisearch` result objects
+# See https://ddnexus.github.io/pagy/docs/extras/meilisearch
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or searchkick extra that define the same method
+# Pagy::DEFAULT[:meilisearch_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:meilisearch_search] = :ms_search
+# require 'pagy/extras/meilisearch'
+
+# Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
+# See https://ddnexus.github.io/pagy/docs/extras/metadata
+# you must require the frontend helpers internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
+# require 'pagy/extras/frontend_helpers'
+# require 'pagy/extras/metadata'
+# For performance reasons, you should explicitly set ONLY the metadata you use in the frontend
+# Pagy::DEFAULT[:metadata] = %i[scaffold_url page prev next last]   # example
+
+# Searchkick extra: Paginate `Searchkick::Results` objects
+# See https://ddnexus.github.io/pagy/docs/extras/searchkick
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or meilisearch extra that defines the same
+# DEFAULT[:searchkick_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:searchkick_search] = :search
+# require 'pagy/extras/searchkick'
+# uncomment if you are going to use Searchkick.pagy_search
+# Searchkick.extend Pagy::Searchkick
+
+
+# Frontend Extras
+
+# Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
+# See https://ddnexus.github.io/pagy/docs/extras/bootstrap
+# require 'pagy/extras/bootstrap'
+
+# Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
+# See https://ddnexus.github.io/pagy/docs/extras/bulma
+# require 'pagy/extras/bulma'
+
+# Foundation extra: Add nav, nav_js and combo_nav_js helpers and templates for Foundation pagination
+# See https://ddnexus.github.io/pagy/docs/extras/foundation
+# require 'pagy/extras/foundation'
+
+# Materialize extra: Add nav, nav_js and combo_nav_js helpers for Materialize pagination
+# See https://ddnexus.github.io/pagy/docs/extras/materialize
+# require 'pagy/extras/materialize'
+
+# Navs extra: Add nav_js and combo_nav_js javascript helpers
+# Notice: the other frontend extras add their own framework-styled versions,
+# so require this extra only if you need the unstyled version
+# See https://ddnexus.github.io/pagy/docs/extras/navs
+# require 'pagy/extras/navs'
+
+# Semantic extra: Add nav, nav_js and combo_nav_js helpers for Semantic UI pagination
+# See https://ddnexus.github.io/pagy/docs/extras/semantic
+# require 'pagy/extras/semantic'
+
+# UIkit extra: Add nav helper and templates for UIkit pagination
+# See https://ddnexus.github.io/pagy/docs/extras/uikit
+# require 'pagy/extras/uikit'
+
+# Multi size var used by the *_nav_js helpers
+# See https://ddnexus.github.io/pagy/docs/extras/navs#steps
+# Pagy::DEFAULT[:steps] = { 0 => [2,3,3,2], 540 => [3,5,5,3], 720 => [5,7,7,5] }   # example
+
+
+# Feature Extras
+
+# Gearbox extra: Automatically change the number of items per page depending on the page number
+# See https://ddnexus.github.io/pagy/docs/extras/gearbox
+# require 'pagy/extras/gearbox'
+# set to false only if you want to make :gearbox_extra an opt-in variable
+# Pagy::DEFAULT[:gearbox_extra] = false               # default true
+# Pagy::DEFAULT[:gearbox_items] = [15, 30, 60, 100]   # default
+
+# Items extra: Allow the client to request a custom number of items per page with an optional selector UI
+# See https://ddnexus.github.io/pagy/docs/extras/items
+# require 'pagy/extras/items'
+# set to false only if you want to make :items_extra an opt-in variable
+# Pagy::DEFAULT[:items_extra] = false    # default true
+# Pagy::DEFAULT[:items_param] = :items   # default
+# Pagy::DEFAULT[:max_items]   = 100      # default
+
+# Overflow extra: Allow for easy handling of overflowing pages
+# See https://ddnexus.github.io/pagy/docs/extras/overflow
+# require 'pagy/extras/overflow'
+# Pagy::DEFAULT[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+
+# Support extra: Extra support for features like: incremental, infinite, auto-scroll pagination
+# See https://ddnexus.github.io/pagy/docs/extras/support
+# require 'pagy/extras/support'
+
+# Trim extra: Remove the page=1 param from links
+# See https://ddnexus.github.io/pagy/docs/extras/trim
+# require 'pagy/extras/trim'
+# set to false only if you want to make :trim_extra an opt-in variable
+# Pagy::DEFAULT[:trim_extra] = false # default true
+
+# Standalone extra: Use pagy in non Rack environment/gem
+# See https://ddnexus.github.io/pagy/docs/extras/standalone
+# require 'pagy/extras/standalone'
+# Pagy::DEFAULT[:url] = 'http://www.example.com/subdir'  # optional default
+
+
+# Rails
+# Enable the .js file required by the helpers that use javascript
+# (pagy*_nav_js, pagy*_combo_nav_js, and pagy_items_selector_js)
+# See https://ddnexus.github.io/pagy/docs/extras#javascript
+
+# With the asset pipeline
+# Sprockets need to look into the pagy javascripts dir, so add it to the assets paths
+# Rails.application.config.assets.paths << Pagy.root.join('javascripts')
+
+# I18n
+
+# Pagy internal I18n: ~18x faster using ~10x less memory than the i18n gem
+# See https://ddnexus.github.io/pagy/docs/api/frontend#i18n
+# Notice: No need to configure anything in this section if your app uses only "en"
+# or if you use the i18n extra below
+#
+# Examples:
+# load the "de" built-in locale:
+# Pagy::I18n.load(locale: 'de')
+#
+# load the "de" locale defined in the custom file at :filepath:
+# Pagy::I18n.load(locale: 'de', filepath: 'path/to/pagy-de.yml')
+#
+# load the "de", "en" and "es" built-in locales:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'de' },
+#                 { locale: 'en' },
+#                 { locale: 'es' })
+#
+# load the "en" built-in locale, a custom "es" locale,
+# and a totally custom locale complete with a custom :pluralize proc:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'en' },
+#                 { locale: 'es', filepath: 'path/to/pagy-es.yml' },
+#                 { locale: 'xyz',  # not built-in
+#                   filepath: 'path/to/pagy-xyz.yml',
+#                   pluralize: lambda{ |count| ... } )
+
+
+# I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
+# than the default pagy internal i18n (see above)
+# See https://ddnexus.github.io/pagy/docs/extras/i18n
+# require 'pagy/extras/i18n'
+
+# Default i18n key
+# Pagy::DEFAULT[:i18n_key] = 'pagy.item_name'   # default
+
+
+# When you are done setting your own default freeze it, so it will not get changed accidentally
+Pagy::DEFAULT.freeze

--- a/lib/slack-ruby-bot-server/config/pagy.rb
+++ b/lib/slack-ruby-bot-server/config/pagy.rb
@@ -4,19 +4,16 @@
 # Customize only what you really need and notice that the core Pagy works also without any of the following lines.
 # Should you just cherry pick part of this file, please maintain the require-order of the extras
 
-
 # Pagy DEFAULT Variables
 # See https://ddnexus.github.io/pagy/docs/api/pagy#variables
 # All the Pagy::DEFAULT are set for all the Pagy instances but can be overridden per instance by just passing them to
 # Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
-
 
 # Instance variables
 # See https://ddnexus.github.io/pagy/docs/api/pagy#instance-variables
 # Pagy::DEFAULT[:page]   = 1                                  # default
 # Pagy::DEFAULT[:items]  = 20                                 # default
 # Pagy::DEFAULT[:outset] = 0                                  # default
-
 
 # Other Variables
 # See https://ddnexus.github.io/pagy/docs/api/pagy#other-variables
@@ -30,10 +27,8 @@
 # Pagy::DEFAULT[:cycle]      = true                            # example
 # Pagy::DEFAULT[:request_path] = "/foo"                        # example
 
-
 # Extras
 # See https://ddnexus.github.io/pagy/docs/extras
-
 
 # Backend Extras
 
@@ -118,7 +113,6 @@
 # uncomment if you are going to use Searchkick.pagy_search
 # Searchkick.extend Pagy::Searchkick
 
-
 # Frontend Extras
 
 # Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
@@ -154,7 +148,6 @@
 # Multi size var used by the *_nav_js helpers
 # See https://ddnexus.github.io/pagy/docs/extras/navs#steps
 # Pagy::DEFAULT[:steps] = { 0 => [2,3,3,2], 540 => [3,5,5,3], 720 => [5,7,7,5] }   # example
-
 
 # Feature Extras
 
@@ -192,7 +185,6 @@
 # See https://ddnexus.github.io/pagy/docs/extras/standalone
 # require 'pagy/extras/standalone'
 # Pagy::DEFAULT[:url] = 'http://www.example.com/subdir'  # optional default
-
 
 # Rails
 # Enable the .js file required by the helpers that use javascript
@@ -232,7 +224,6 @@
 #                   filepath: 'path/to/pagy-xyz.yml',
 #                   pluralize: lambda{ |count| ... } )
 
-
 # I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
 # than the default pagy internal i18n (see above)
 # See https://ddnexus.github.io/pagy/docs/extras/i18n
@@ -240,7 +231,6 @@
 
 # Default i18n key
 # Pagy::DEFAULT[:i18n_key] = 'pagy.item_name'   # default
-
 
 # When you are done setting your own default freeze it, so it will not get changed accidentally
 Pagy::DEFAULT.freeze

--- a/lib/slack-ruby-bot-server/version.rb
+++ b/lib/slack-ruby-bot-server/version.rb
@@ -1,3 +1,3 @@
 module SlackRubyBotServer
-  VERSION = '1.2.2'.freeze
+  VERSION = '2.0.0'.freeze
 end

--- a/slack-ruby-bot-server.gemspec
+++ b/slack-ruby-bot-server.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'grape-roar', '>= 0.4.0'
   spec.add_dependency 'grape-swagger'
   spec.add_dependency 'kaminari-grape'
+  spec.add_dependency 'pagy_cursor'
   spec.add_dependency 'rack-cors'
   spec.add_dependency 'rack-rewrite'
   spec.add_dependency 'rack-server-pages'
   spec.add_dependency 'slack-ruby-client'
-  spec.add_dependency 'pagy_cursor'
 end

--- a/slack-ruby-bot-server.gemspec
+++ b/slack-ruby-bot-server.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rack-rewrite'
   spec.add_dependency 'rack-server-pages'
   spec.add_dependency 'slack-ruby-client'
+  spec.add_dependency 'pagy_cursor'
 end

--- a/slack-ruby-bot-server.gemspec
+++ b/slack-ruby-bot-server.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'grape-roar', '>= 0.4.0'
   spec.add_dependency 'grape-swagger'
   spec.add_dependency 'kaminari-grape'
-  spec.add_dependency 'pagy_cursor'
   spec.add_dependency 'rack-cors'
   spec.add_dependency 'rack-rewrite'
   spec.add_dependency 'rack-server-pages'


### PR DESCRIPTION
Close #148 #126   
[cursor_pagination](https://github.com/Kukunin/cursor_pagination) is abandoned and no longer maintained.  
This PR replaces it with [pagy_cursor](https://github.com/Uysim/pagy-cursor), a cursor pagination gem based on [pagy](https://github.com/ddnexus/pagy).