### PR TITLE
Fix: scope are comma-separated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#158](https://github.com/slack-ruby/slack-ruby-bot-server/pull/158): Replace `cursor_pagination` with `pagy_cursor` - [@crazyoptimist](https://github.com/crazyoptimist).
 * [#160](https://github.com/slack-ruby/slack-ruby-bot-server/pull/160): Document upgrading to 2.0.0 - [@crazyoptimist](https://github.com/crazyoptimist).
 * [#161](https://github.com/slack-ruby/slack-ruby-bot-server/pull/161): Removed unused `ext` module - [@dblock](https://github.com/dblock).
+* [#162](https://github.com/slack-ruby/slack-ruby-bot-server/pull/162): Fix: scopes are comma-separated - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 #### 1.2.1 (2022/03/06)

--- a/lib/slack-ruby-bot-server/config.rb
+++ b/lib/slack-ruby-bot-server/config.rb
@@ -53,7 +53,7 @@ module SlackRubyBotServer
     end
 
     def oauth_scope_s
-      oauth_scope&.join('+')
+      oauth_scope&.join(',')
     end
 
     def activerecord?

--- a/spec/integration/teams_spec.rb
+++ b/spec/integration/teams_spec.rb
@@ -38,7 +38,7 @@ describe 'Teams', js: true, type: :feature do
       end
       it 'includes a link to add to slack with the client id' do
         expect(title).to eq('Slack Ruby Bot Server')
-        expect(find("a[href='https://slack.com/oauth/authorize?scope=channels:read+channels:write&client_id=client_id"))
+        expect(find("a[href='https://slack.com/oauth/authorize?scope=channels:read,channels:write&client_id=client_id"))
       end
     end
   end
@@ -68,7 +68,7 @@ describe 'Teams', js: true, type: :feature do
       end
       it 'includes a link to add to slack with the client id' do
         expect(title).to eq('Slack Ruby Bot Server')
-        expect(find("a[href='https://slack.com/oauth/v2/authorize?scope=channels:read+channels:write&client_id=client_id"))
+        expect(find("a[href='https://slack.com/oauth/v2/authorize?scope=channels:read,channels:write&client_id=client_id"))
       end
     end
   end


### PR DESCRIPTION
According to https://api.slack.com/authentication/oauth-v2 multiple scopes are comma-separated. Both might actually work.