### PR TITLE
Fix timers to run independently, add once_and_every.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#163](https://github.com/slack-ruby/slack-ruby-bot-server/pull/163): Updated releasing documentation - [@crazyoptimist](https://github.com/crazyoptimist).
 * [#164](https://github.com/slack-ruby/slack-ruby-bot-server/pull/164): Added support for Rails 6.1 and 7.0 - [@maths22](https://github.com/maths22).
 * [#168](https://github.com/slack-ruby/slack-ruby-bot-server/pull/168): Added support for Ruby 3.2.1 - [@dblock](https://github.com/dblock).
+* [#167](https://github.com/slack-ruby/slack-ruby-bot-server/pull/167): Added `once_and_every` timer - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 #### 2.0.1 (2023/02/20)

--- a/README.md
+++ b/README.md
@@ -238,9 +238,7 @@ end
 
 ##### Service Timers
 
-You can introduce custom behavior into the service lifecycle on a timer. For example, check whether a team's trial has expired, or periodically cleanup data.
-
-Note that unlike callbacks, timers are global for the entire service.
+You can introduce custom behavior into the service lifecycle on a timer. For example, check whether a team's trial has expired, or periodically clean-up data. Timers can run once on start (`once_and_every`) and start running after a certain period (`every`).
 
 ```ruby
 instance = SlackRubyBotServer::Service.instance
@@ -252,6 +250,10 @@ instance.every :hour do
     rescue StandardError
     end
   end
+end
+
+instance.once_and_every :minute do
+  # called once on start, then every minute
 end
 
 instance.every :minute do
@@ -266,6 +268,8 @@ instance.every 30 do
   # called every 30 seconds
 end
 ```
+
+Note that, unlike callbacks, timers are global for the entire service. Timers are independent, and a failing timer will not terminate other timers.
 
 ##### Extensions
 


### PR DESCRIPTION
Ensure a failing timer doesn't affect other timers.

Added `once_and_every`.