### PR TITLE
Update README Postgres example for Ruby 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,19 +104,15 @@ Establish a connection in your startup code.
 # Reference: https://bugs.ruby-lang.org/issues/17866
 config = begin
   YAML.safe_load(
-    ERB.new(
-      File.read('config/postgresql.yml')
-    ).result, aliases: true
+    File.read('config/postgresql.yml'), aliases: true
   )[ENV['RACK_ENV']]
 rescue ArgumentError
   YAML.safe_load(
-    ERB.new(
-      File.read('config/postgresql.yml')
-    ).result, [], [], true
+    File.read('config/postgresql.yml'), [], [], true
   )[ENV['RACK_ENV']]
 end
 
-ActiveRecord::Base.establish_connection(config)
+ActiveRecord::Base.establish_connection(ERB.new(config).result)
 ```
 
 ### OAuth Version and Scopes

--- a/README.md
+++ b/README.md
@@ -100,13 +100,23 @@ production:
 Establish a connection in your startup code.
 
 ```ruby
-ActiveRecord::Base.establish_connection(
+# Ensure that YAML can load with all versions of Ruby and Psych.
+# Reference: https://bugs.ruby-lang.org/issues/17866
+config = begin
+  YAML.safe_load(
+    ERB.new(
+      File.read('config/postgresql.yml')
+    ).result, aliases: true
+  )[ENV['RACK_ENV']]
+rescue ArgumentError
   YAML.safe_load(
     ERB.new(
       File.read('config/postgresql.yml')
     ).result, [], [], true
   )[ENV['RACK_ENV']]
-)
+end
+
+ActiveRecord::Base.establish_connection(config)
 ```
 
 ### OAuth Version and Scopes


### PR DESCRIPTION
The current example only works with pre 3.1 and pre Psych 4. Upgrade it to work with all versions.

- Ref: https://bugs.ruby-lang.org/issues/17866
- Ref: https://github.com/rails/rails/commit/179d0a1f474ada02e0030ac3bd062fc653765dbe