### PR TITLE
fix(ActiveRecord): correctly connect to database in Rails 7.2+

### DIFF
--- a/.github/workflows/test-postgresql.yml
+++ b/.github/workflows/test-postgresql.yml
@@ -10,6 +10,7 @@ jobs:
           - { ruby: 2.6.2, postgresql: 11, active_record: '~> 6.0.0' }
           - { ruby: 3.1.1, postgresql: 11, active_record: '~> 6.1.0' }
           - { ruby: 3.1.1, postgresql: 14, active_record: '~> 7.0.0' }
+          - { ruby: 3.1.1, postgresql: 14, active_record: '~> 7.2.0' }
     name: test (ruby=${{ matrix.entry.ruby }}, postgresql=${{ matrix.entry.postgresql }}, active_record=${{ matrix.entry.active_record }})
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 2.1.2 (Next)
 
 * Your contribution here.
+* [#175](https://github.com/slack-ruby/slack-ruby-bot-server/pull/175): Fix(activerecord): correctly check for database in rails 7.2+ - [@markokajzer](https://github.com/markokajzer).
 
 ### 2.1.1 (2023/07/25)
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ when 'mongoid' then
 when 'activerecord' then
   gem 'activerecord', ENV['ACTIVERECORD_VERSION'] || '~> 6.0.0'
   gem 'otr-activerecord'
-  gem 'pagy_cursor'
+  gem 'pagy_cursor', '~> 0.6.1'
   gem 'pg'
 when nil
   warn "Missing ENV['DATABASE_ADAPTER']."
@@ -23,7 +23,7 @@ group :development, :test do
   gem 'bundler'
   gem 'byebug'
   gem 'capybara', '~> 3.36.0'
-  gem 'database_cleaner', '~> 1.8.5'
+  gem 'database_cleaner', '~> 2.1.0'
   gem 'fabrication'
   gem 'faker'
   gem 'faraday', '0.17.5'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ case ENV.fetch('DATABASE_ADAPTER', nil)
 when 'mongoid' then
   gem 'kaminari-mongoid'
   gem 'mongoid', ENV['MONGOID_VERSION'] || '~> 7.3.0'
-  gem 'mongoid-scroll'
+  gem 'mongoid-scroll', '~> 1.0.1'
   gem 'mongoid-shell'
 
   group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,19 @@ when 'mongoid' then
   gem 'mongoid', ENV['MONGOID_VERSION'] || '~> 7.3.0'
   gem 'mongoid-scroll'
   gem 'mongoid-shell'
+
+  group :development, :test do
+    gem 'database_cleaner-mongoid', '~> 2.0.1'
+  end
 when 'activerecord' then
   gem 'activerecord', ENV['ACTIVERECORD_VERSION'] || '~> 6.0.0'
   gem 'otr-activerecord'
   gem 'pagy_cursor', '~> 0.6.1'
   gem 'pg'
+
+  group :development, :test do
+    gem 'database_cleaner-active_record', '~> 2.2.0'
+  end
 when nil
   warn "Missing ENV['DATABASE_ADAPTER']."
 else
@@ -23,7 +31,6 @@ group :development, :test do
   gem 'bundler'
   gem 'byebug'
   gem 'capybara', '~> 3.36.0'
-  gem 'database_cleaner', '~> 2.1.0'
   gem 'fabrication'
   gem 'faker'
   gem 'faraday', '0.17.5'

--- a/lib/slack-ruby-bot-server/config/database_adapters/activerecord.rb
+++ b/lib/slack-ruby-bot-server/config/database_adapters/activerecord.rb
@@ -6,7 +6,12 @@ require 'pagy_cursor/pagy/extras/cursor'
 module SlackRubyBotServer
   module DatabaseAdapter
     def self.check!
-      ActiveRecord::Base.connection_pool.with_connection(&:active?)
+      if ActiveRecord.version >= Gem::Version.new('7.2')
+        ActiveRecord::Base.connection.database_exists?
+      else
+        ActiveRecord::Base.connection_pool.with_connection(&:active?)
+      end
+
       raise 'Unexpected error.' unless ActiveRecord::Base.connected?
     rescue StandardError => e
       warn "Error connecting to PostgreSQL: #{e.message}"

--- a/spec/database_adapters/activerecord/database_cleaner.rb
+++ b/spec/database_adapters/activerecord/database_cleaner.rb
@@ -1,0 +1,14 @@
+require 'database_cleaner/active_record'
+
+RSpec.configure do |config|
+  config.before :suite do
+    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.clean_with :truncation
+  end
+
+  config.around :each do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
+end

--- a/spec/database_adapters/mongoid/database_cleaner.rb
+++ b/spec/database_adapters/mongoid/database_cleaner.rb
@@ -1,9 +1,9 @@
-require 'database_cleaner'
+require 'database_cleaner/mongoid'
 
 RSpec.configure do |config|
   config.before :suite do
-    DatabaseCleaner.strategy = :truncation
-    DatabaseCleaner.clean_with :truncation
+    DatabaseCleaner.strategy = :deletion
+    DatabaseCleaner.clean_with :deletion
   end
 
   config.around :each do |example|

--- a/spec/slack-ruby-bot-server/app_spec.rb
+++ b/spec/slack-ruby-bot-server/app_spec.rb
@@ -13,6 +13,41 @@ describe SlackRubyBotServer::App do
       expect(app.instance).to be_an_instance_of(app)
     end
   end
+  context '#prepare!' do
+    context 'when connection cannot be established' do
+      context 'with ActiveRecord >= 7.2' do
+        before do
+          skip 'incorrect ActiveRecord version' if ActiveRecord.version < Gem::Version.new('7.2')
+
+          # Make sure ActiveRecord is not connected in any way before the spec starts
+          ActiveRecord::Base.connection_pool.disconnect!
+        end
+
+        it 'raises' do
+          expect(ActiveRecord::Base).not_to be_connected
+
+          # Simulate that #database_exists? does not connect to the database
+          allow(ActiveRecord::Base).to receive_message_chain(:connection, :database_exists?)
+          expect { subject.prepare! }
+            .to raise_error('Unexpected error.')
+        end
+      end
+
+      context 'with ActiveRecord < 7.2' do
+        before do
+          skip 'incorrect ActiveRecord version' if ActiveRecord.version >= Gem::Version.new('7.2')
+        end
+
+        it 'raises' do
+          # In ActiveRecord < 7.1, `disconnect!` closes the connection that has already been leased by
+          #   DatabaseCleaner, so we cannot do that trick here to simulate a not established connection.
+          allow(ActiveRecord::Base).to receive(:connected?).and_return(false)
+          expect { subject.prepare! }
+            .to raise_error('Unexpected error.')
+        end
+      end
+    end
+  end
   context '#purge_inactive_teams!' do
     it 'purges teams' do
       expect(Team).to receive(:purge!)

--- a/spec/slack-ruby-bot-server/app_spec.rb
+++ b/spec/slack-ruby-bot-server/app_spec.rb
@@ -17,6 +17,7 @@ describe SlackRubyBotServer::App do
     context 'when connection cannot be established' do
       context 'with ActiveRecord >= 7.2' do
         before do
+          skip 'incorrect database adapter' unless ENV['DATABASE_ADAPTER'] == 'activerecord'
           skip 'incorrect ActiveRecord version' if ActiveRecord.version < Gem::Version.new('7.2')
 
           # Make sure ActiveRecord is not connected in any way before the spec starts
@@ -35,6 +36,7 @@ describe SlackRubyBotServer::App do
 
       context 'with ActiveRecord < 7.2' do
         before do
+          skip 'incorrect database adapter' unless ENV['DATABASE_ADAPTER'] == 'activerecord'
           skip 'incorrect ActiveRecord version' if ActiveRecord.version >= Gem::Version.new('7.2')
         end
 


### PR DESCRIPTION
`ActiveRecord::Base.connection_pool.with_connection(&:active?)` was used to establish a connection to the database, so that subsequently `ActiveRecord::Base.connected?` becomes true.

In Rails 7.2, this is not the case anymore, and `ActiveRecord::Base.connection_pool.with_connection(&:active?)` does not flip `ActiveRecord::Base.connected?`

Instead, what we can do is perform a direct check like `ActiveRecord::Base.connection.database_exists?`. Also see https://github.com/rails/rails/issues/52946.

![Screenshot 2024-11-27 at 12 58 37](https://github.com/user-attachments/assets/bfe5de42-3575-48c3-a4f5-ea0611b6f204)
